### PR TITLE
Fix: Add include <limits> in cxxoptd.hpp file to enable gcc to compil…

### DIFF
--- a/Source/cxxopts.hpp
+++ b/Source/cxxopts.hpp
@@ -37,6 +37,7 @@ THE SOFTWARE.
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <limits>
 
 #ifdef __cpp_lib_optional
 #include <optional>


### PR DESCRIPTION
…e the project.

Without this include you get after "cmake ./" and "make" this error many times:
error: ‘numeric_limits’ is not a member of ‘std’

?> gcc --version
gcc (Ubuntu 12.2.0-3ubuntu1) 12.2.0

Linux Ubuntu 22.10